### PR TITLE
Fix: authoring fail to start.

### DIFF
--- a/services/publishing/scripts/init-git.sh
+++ b/services/publishing/scripts/init-git.sh
@@ -54,7 +54,7 @@ chown -R git:git /home/git
 cd $REPO_LOCATION
 # clone the source repository and apply hooks
 set -e
-su - git -s "/bin/bash" -c "cd `pwd` && source ~/.env && git clone --bare $GIT_UPSTREAM_URI ."
+su - git -s "/bin/bash" -c "cd `pwd` && source ~/.env && git clone --bare $GIT_UPSTREAM_URI ."; wait
 cp /tweek/hooks/* $REPO_LOCATION/hooks/
 set +e
 


### PR DESCRIPTION
When using a big rules repo, the clone takes a while and the authoring fail to start.